### PR TITLE
Update walkthrough.go

### DIFF
--- a/internal/genOspa/walkthrough.go
+++ b/internal/genOspa/walkthrough.go
@@ -72,7 +72,7 @@ func AskClientOSPAFileParameters(serverPublicKey *rsa.PublicKey) (OSPAFileParame
 
 	if clientDeviceId == "" {
 		log.Debug("Generating random client device UUID...")
-		clientDeviceId = uuid.Must(uuid.NewV4()).String()
+		clientDeviceId = uuid.Must(uuid.NewV4(),err).String()
 		log.WithField("clientDeviceId", clientDeviceId).Info("Generated random client device UUID")
 	}
 

--- a/internal/server/receiving.go
+++ b/internal/server/receiving.go
@@ -159,7 +159,7 @@ func (n *New) initiateRequestPipeline(packet request.Packet, clientPubKey *rsa.P
 	}).Debug("User is authorized")
 
 	// Generate a connectionId for the firewall tracker
-	connIdUUID, err := uuid.NewV4()
+	connIdUUID := uuid.NewV4()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
缺少参数，在编译的时候报错。
walkthrough.go:75:29: not enough arguments in call to uuid.Must
        have (uuid.UUID)
        want (uuid.UUID, error)